### PR TITLE
Remove bubbling up from course states

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
           name: Install required libraries
           command: |
             sudo apt-get install -y libzip-dev
-            sudo docker-php-ext-install zip
-            sudo docker-php-ext-install pcntl
+            sudo docker-php-ext-install zip pcntl
       - run:
           name: Install dependencies
           command: |

--- a/src/Service/Contentful.php
+++ b/src/Service/Contentful.php
@@ -140,7 +140,7 @@ class Contentful
         $courses = $this->client->getEntries($query)->getItems();
 
         if ($courses && $this->state->hasEditorialFeaturesLink()) {
-            $this->entryStateChecker->computeState($courses, 'getLessons');
+            $this->entryStateChecker->computeState(...$courses);
         }
 
         return $courses;
@@ -162,7 +162,7 @@ class Contentful
         $course = $this->findEntry('course', $courseSlug);
 
         if ($course && $this->state->hasEditorialFeaturesLink()) {
-            $this->entryStateChecker->computeState([$course], 'getLessons');
+            $this->entryStateChecker->computeState($course);
         }
 
         return $course;
@@ -198,15 +198,16 @@ class Contentful
         $course->nextLesson = $lessons[$lessonIndex + 1] ?? null;
 
         if ($this->state->hasEditorialFeaturesLink()) {
-            $this->entryStateChecker->computeState([$course->lesson], 'getModules');
+            $course->lesson->children = $course->lesson->getModules();
+            $this->entryStateChecker->computeState($course->lesson);
         }
 
         return $course;
     }
 
     /**
-     * @param array  $lessons
-     * @param string $lessonSlug
+     * @param DynamicEntry[] $lessons
+     * @param string         $lessonSlug
      *
      * @return int|null
      */
@@ -235,7 +236,8 @@ class Contentful
         $landingPage = $this->findEntry('layout', $slug, 3);
 
         if ($landingPage && $this->state->hasEditorialFeaturesLink()) {
-            $this->entryStateChecker->computeState([$landingPage], 'getContentModules');
+            $landingPage->children = $landingPage->getContentModules();
+            $this->entryStateChecker->computeState($landingPage);
         }
 
         return $landingPage;


### PR DESCRIPTION
The `EntryStateChecker` class was previously expecting a method name which was used to access an entry's linked entries. Now that class expects that an entry object has a property called `children`, which is an array of entry objects.

This is done so the responsibility of resolving the relationship between object shifts from the `EntryStateChecker` to the `Contentful` class.

Also, I changed the ways entry objects were passed, using a trick with variadic arguments (`...`) so I can also enforce types on an array.